### PR TITLE
Add Web Stories IA plugin prototype

### DIFF
--- a/web-stories-ia/README.md
+++ b/web-stories-ia/README.md
@@ -6,6 +6,7 @@ Plugin complementario para [Web Stories](https://wordpress.org/plugins/web-stori
 
 - Configuración de la clave de API de OpenAI con verificación.
 - Página de administración para generar historias basadas en plantillas existentes.
+- Generación página por página empleando el modelo `gpt-4o-mini` para reducir el uso de tokens.
 - Creación automática de un borrador de historia (`web-story`) con título, descripción y páginas generadas por IA.
 
 > **Nota:** Este es un prototipo inicial. La selección de imágenes, categorías y etiquetas se deberán implementar en futuras versiones.


### PR DESCRIPTION
## Summary
- add `web-stories-ia` plugin with settings page to store and verify an OpenAI API key
- include admin page to generate draft web stories from templates using the OpenAI `gpt-4o-mini` model
- document plugin usage

## Testing
- `php -l web-stories-ia/web-stories-ia.php`
- `npm test` *(fails: npm-run-all: not found; engine requires node>=22)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e68b96ec8325ac963a48ea87b8ea